### PR TITLE
Add Windows release packaging and Streamlit preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.venv/
+build/
+dist/
+release/

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,8 @@
+[server]
+headless = true
+
+[theme]
+primaryColor = "#f745e0"
+backgroundColor = "#ffffff"
+secondaryBackgroundColor = "#f0f0f0"
+textColor = "#2e2e2e"

--- a/README.md
+++ b/README.md
@@ -1,31 +1,52 @@
 # UpNote
-A lightweight markdown editor built with Python that supports basic markdown syntax.
+
+A lightweight Markdown editor built with Python. The desktop app uses PyQt6 and includes a live preview; the same editor is available as a browser preview on Streamlit Community Cloud.
+
+[![Open live app](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://upnote.streamlit.app)
 
 ## Features
-- Supports basic Markdown syntax
-- Syntax highlighting (=="element"==)
-- Simple and user-friendly interface
+
+- Markdown editor with live HTML preview
+- Syntax highlighting for headings, emphasis, code, highlights, subscript and superscript
+- Light/dark theme
+- Open and save `.md` files
+- PNG background and icon assets preserved with alpha transparency in desktop builds
+- Browser preview with upload and download support
 
 ## Requirements
-- **Python 3.6+**  
-  [Download Python](https://www.python.org/downloads/)
-  
-- **Microsoft Visual C++ 14.0 or greater**  
-  [Download Visual C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
-  
-- **PyQt6**  
-  ```
-  pip install PyQt6
-  ```
 
-- **Markdown**  
-  ```
-  pip install markdown
-  ```
+Python 3.12+ is recommended for the Windows build.
 
-## Usage
-- Open the application either via file explorer or console, and you can start writing markdown.
+## Run locally
 
+```powershell
+py -3 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
+python upnote.py
+```
 
-## Future
-- Building it into an .exe program format, once it leaves the development phase.
+To run the browser preview locally:
+
+```powershell
+streamlit run streamlit_app.py
+```
+
+## Windows release
+
+Build a portable Windows executable and ZIP package:
+
+```powershell
+.\build_release.ps1 1.0.0
+```
+
+The output is created under `release\` as `UpNote-1.0.0-windows.zip`. The package is portable and includes the PNG assets; no Python installation is needed to run `UpNote.exe`.
+
+## Streamlit Cloud deployment
+
+1. Open [Streamlit Community Cloud](https://share.streamlit.io/).
+2. Choose **Deploy an app**, select `lukaazman/UpNote`, branch `main`, and file `streamlit_app.py`.
+3. Set the app name to `upnote` (or update the badge URL above if another name is chosen).
+4. Every push to `main` redeploys the preview automatically.
+
+The live preview is intended for quick browser testing of the Markdown editor. The full PyQt6 desktop experience remains available in the Windows release package.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,5 @@
+# UpNote 1.0.0
+
+- Portable Windows executable with bundled PNG assets.
+- Light/dark desktop themes and Markdown preview.
+- Streamlit browser preview entrypoint included.

--- a/UpNote.spec
+++ b/UpNote.spec
@@ -1,0 +1,15 @@
+# -*- mode: python ; coding: utf-8 -*-
+from pathlib import Path
+
+project_dir = Path(SPEC).parent
+
+a = Analysis(
+    [str(project_dir / "upnote.py")], pathex=[str(project_dir)], binaries=[],
+    datas=[(str(project_dir / "background.png"), "."), (str(project_dir / "icon.png"), ".")],
+    hiddenimports=["markdown.extensions.extra", "markdown.extensions.sane_lists"],
+    hookspath=[], hooksconfig={}, runtime_hooks=[], excludes=[], noarchive=False,
+)
+pyz = PYZ(a.pure)
+exe = EXE(pyz, a.scripts, a.binaries, a.datas, [], name="UpNote", debug=False,
+         bootloader_ignore_signals=False, strip=False, upx=True, console=False,
+         icon=str(project_dir / "icon.png"))

--- a/build_release.ps1
+++ b/build_release.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+$version = if ($args.Count -gt 0) { $args[0] } else { "1.0.0" }
+$releaseDir = Join-Path $PSScriptRoot "release\UpNote-$version-windows"
+if (Test-Path -LiteralPath $releaseDir) { Remove-Item -LiteralPath $releaseDir -Recurse -Force }
+New-Item -ItemType Directory -Path $releaseDir | Out-Null
+py -3.12 -m PyInstaller --noconfirm --clean --distpath $releaseDir --workpath (Join-Path $PSScriptRoot "build") (Join-Path $PSScriptRoot "UpNote.spec")
+if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed with exit code $LASTEXITCODE" }
+Copy-Item -LiteralPath (Join-Path $PSScriptRoot "README.md") -Destination $releaseDir
+$zipPath = Join-Path $PSScriptRoot "release\UpNote-$version-windows.zip"
+if (Test-Path -LiteralPath $zipPath) { Remove-Item -LiteralPath $zipPath -Force }
+Compress-Archive -Path (Join-Path $releaseDir "*") -DestinationPath $zipPath
+Write-Host "Created $zipPath"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+PyQt6>=6.9,<7
+PyQt6-WebEngine>=6.9,<7
+Markdown>=3.7,<4
+streamlit>=1.45,<2
+pyinstaller>=6.13,<7

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,32 @@
+"""Browser preview for UpNote, suitable for Streamlit Community Cloud."""
+
+import markdown
+import streamlit as st
+
+st.set_page_config(page_title="UpNote preview", page_icon="📝", layout="wide")
+st.title("UpNote")
+st.caption("Markdown editor preview — changes render instantly in the browser.")
+
+default_text = """# Welcome to UpNote
+
+Write **Markdown** on the left and see the rendered preview on the right.
+
+==Highlight==, `inline code`, and [links](https://github.com/lukaazman/UpNote) are supported.
+"""
+
+if "content" not in st.session_state:
+    st.session_state.content = default_text
+
+uploaded = st.file_uploader("Open a Markdown file", type=["md", "markdown"])
+if uploaded is not None:
+    st.session_state.content = uploaded.getvalue().decode("utf-8")
+
+left, right = st.columns(2)
+with left:
+    st.subheader("Editor")
+    content = st.text_area("Markdown source", key="content", height=520, label_visibility="collapsed")
+    st.download_button("Save Markdown", data=content, file_name="upnote.md", mime="text/markdown")
+
+with right:
+    st.subheader("Preview")
+    st.markdown(markdown.markdown(content, extensions=["extra", "sane_lists"]), unsafe_allow_html=True)

--- a/upnote.py
+++ b/upnote.py
@@ -1,13 +1,25 @@
 import sys
 import re
+from pathlib import Path
 from PyQt6.QtWidgets import (
-    QApplication, QMainWindow, QTextEdit, QVBoxLayout, QWidget, QFileDialog, 
+    QApplication, QMainWindow, QTextEdit, QVBoxLayout, QWidget, QFileDialog,
     QHBoxLayout, QFrame
 )
 from PyQt6.QtGui import QAction, QIcon, QSyntaxHighlighter, QTextCharFormat, QColor
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtCore import QRegularExpression, Qt
 import markdown
+
+def resource_path(filename):
+    """Return an asset path that works from source and from a PyInstaller build."""
+    bundle_dir = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
+    return str(bundle_dir / filename)
+
+
+def stylesheet_asset_url(filename):
+    """Format a local asset path for a Qt stylesheet URL."""
+    return resource_path(filename).replace("\\", "/").replace(" ", "%20")
+
 
 class MarkdownHighlighter(QSyntaxHighlighter):
     def __init__(self, document):
@@ -155,7 +167,7 @@ class MarkdownEditor(QMainWindow):
         self.create_menu()
 
         self.setWindowTitle("UpNote")
-        self.setWindowIcon(QIcon("icon.png"))
+        self.setWindowIcon(QIcon(resource_path("icon.png")))
         self.showMaximized()
         self.apply_light_theme()
 
@@ -205,9 +217,10 @@ class MarkdownEditor(QMainWindow):
         self.update_preview()
 
     def apply_light_theme(self):
-        self.setStyleSheet("""
+        background_url = stylesheet_asset_url("background.png")
+        self.setStyleSheet(f"""
             QTextEdit {
-                background: url(background.png) no-repeat center center;
+                background: url("{background_url}") no-repeat center center;
                 background-color: white;
                 color: #f745e0;
                 font-size: 30px;
@@ -222,7 +235,7 @@ class MarkdownEditor(QMainWindow):
             }
             QMenuBar::selected {
                 color:#45f1f7;
-                backgound-color: #f745e0;
+                background-color: #f745e0;
             }
             QMenu {
                 background-color: #f0f0f0;
@@ -238,9 +251,10 @@ class MarkdownEditor(QMainWindow):
         """)
 
     def apply_dark_theme(self):
-        self.setStyleSheet("""
+        background_url = stylesheet_asset_url("background.png")
+        self.setStyleSheet(f"""
             QTextEdit {
-                background: url(background.png) no-repeat center center;
+                background: url("{background_url}") no-repeat center center;
                 background-color: #2e2e2e;
                 color: #f745e0;
                 font-size: 30px;


### PR DESCRIPTION
# UpNote 1.0.0

- Portable Windows executable with bundled PNG assets.
- Light/dark desktop themes and Markdown preview.
- Streamlit browser preview entrypoint included.